### PR TITLE
correct 'button' check

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -490,7 +490,9 @@
             }
             smartName[language] = newSmartName;
 
-            if (smartName && (!smartName[language] || (smartName[language] === obj.common.name && (!obj.common.role || obj.common.role.indexOf('button') === -1)))) {
+            if (smartName && (!smartName[language] || 
+			(smartName[language] === obj.common.name && 
+				(!obj.common.role || obj.common.role.indexOf('button') >=0)))) {
                 delete smartName[language];
                 var empty = true;
                 for (var key in smartName) {


### PR DESCRIPTION
cloud adapter does not insert new smart devices if they  have no old smartName defined or the smartName is the same as common.name!
The check should filter out 'buttons' but currently it filters out all other types than button!

I made the change on my local system and it works again.